### PR TITLE
Handle nil http request body

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -38,3 +38,17 @@ func Example_formEncodedBody() {
 	// Output:
 	// 200
 }
+
+func ExampleSignGlacier() {
+	r, _ := http.NewRequest("GET", "https://glacier.us-east-1.amazonaws.com/-/vaults", nil)
+	r.Header.Set("X-Amz-Glacier-Version", "2012-06-01")
+
+	resp, err := aws4.DefaultClient.Do(r)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(resp.StatusCode)
+	// Output:
+	// 200
+}

--- a/sign.go
+++ b/sign.go
@@ -142,11 +142,19 @@ func (s *Service) writeHeaderList(w io.Writer, r *http.Request) {
 }
 
 func (s *Service) writeBody(w io.Writer, r *http.Request) {
-	b, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		panic(err)
+	var b []byte
+	// If the payload is empty, use the empty string as the input to the SHA256 function
+	// http://docs.amazonwebservices.com/general/latest/gr/sigv4-create-canonical-request.html
+	if r.Body == nil {
+		b = []byte("")
+	} else {
+		var err error
+		b, err = ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 	}
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 
 	h := sha256.New()
 	h.Write(b)


### PR DESCRIPTION
I'm implementing a Glacier client in go and a lot of the requests have nil bodies. 

This patch fixes a panic in the current aws4 library when the HTTP request has a nil body.  I also added an example test using a nil body to make sure it works correctly.

Thanks.
