### PR TITLE
Support single-endpoint services

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,7 +45,10 @@ func (c *Client) client() *http.Client {
 }
 
 func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
-	Sign(c.Keys, req)
+	err = Sign(c.Keys, req)
+	if err != nil {
+		return nil, err
+	}
 	return c.client().Do(req)
 }
 

--- a/sign.go
+++ b/sign.go
@@ -48,12 +48,18 @@ type Service struct {
 // Sign signs a request with a Service derived from r.Host
 func Sign(keys *Keys, r *http.Request) error {
 	parts := strings.Split(r.Host, ".")
-	if len(parts) < 4 {
+	
+	sv := new(Service)
+	if len(parts) >= 4 {
+		sv.Name = parts[0]
+		sv.Region = parts[1]
+	} else if len(parts) == 3 {
+		sv.Name = parts[0]
+		sv.Region = "us-east-1"
+	} else {
 		return fmt.Errorf("Invalid AWS Endpoint: %s", r.Host)
 	}
-	sv := new(Service)
-	sv.Name = parts[0]
-	sv.Region = parts[1]
+
 	sv.Sign(keys, r)
 	return nil
 }


### PR DESCRIPTION
STS has only a single endpoint, https://sts.amazonaws.com/. The docs say to assume us-east-1 for single-endpoint services.

(In the commit I said IAM instead of STS.)
