### PR TITLE
KeysFromEnvironment that reports if expected variables are not found

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,22 +1,40 @@
 package aws4
 
 import (
+	"errors"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 )
 
-var DefaultClient = &Client{Keys: KeysFromEnvironment()}
+var DefaultClient *Client
+
+func init() {
+	keys, err := KeysFromEnvironment()
+	if err == nil {
+		DefaultClient = &Client{Keys: keys}
+	} else {
+		log.Println("WARNING:", err)
+	}
+}
 
 // Initializes and returns a Keys using the AWS_ACCESS_KEY and AWS_SECRET_KEY
 // environment variables.
-func KeysFromEnvironment() *Keys {
-	return &Keys{
+func KeysFromEnvironment() (keys *Keys, err error) {
+	keys = &Keys{
 		AccessKey: os.Getenv("AWS_ACCESS_KEY"),
 		SecretKey: os.Getenv("AWS_SECRET_KEY"),
 	}
+	if keys.AccessKey == "" {
+		err = errors.New("AWS_ACCESS_KEY not found in environment")
+	}
+	if keys.SecretKey == "" {
+		err = errors.New("AWS_SECRET_KEY not found in environment")
+	}
+	return keys, err
 }
 
 // Client is like http.Client, but signs all requests using Keys.
@@ -29,11 +47,17 @@ type Client struct {
 
 // Post works like http.Post, but signs the request with Keys.
 func Post(url string, bodyType string, body io.Reader) (resp *http.Response, err error) {
+	if DefaultClient == nil {
+		return nil, errors.New("no DefaultClient")
+	}
 	return DefaultClient.Post(url, bodyType, body)
 }
 
 // PostForm works like http.PostForm, but signs the request with Keys.
 func PostForm(url string, data url.Values) (resp *http.Response, err error) {
+	if DefaultClient == nil {
+		return nil, errors.New("no DefaultClient")
+	}
 	return DefaultClient.PostForm(url, data)
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -2,11 +2,12 @@ package aws4_test
 
 import (
 	"fmt"
-	"github.com/bmizerany/aws4"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"."
 )
 
 func Example_jSONBody() {


### PR DESCRIPTION
When digging into Issue #4 it turned out to be a slight difference in spelling of the environment variables. This change makes such a case an explicit error. Closes #4.
